### PR TITLE
Contribution - Addition of Ticktime and Tick response in the data.py and connect.py files

### DIFF
--- a/integrate/connect.py
+++ b/integrate/connect.py
@@ -114,6 +114,7 @@ class ConnectToIntegrate:
 
     TIMEFRAME_TYPE_MIN = "minute"
     TIMEFRAME_TYPE_DAY = "day"
+    TIMEFRAME_TYPE_TICK = "tick"
 
     def __init__(
         self,
@@ -186,6 +187,7 @@ class ConnectToIntegrate:
         self.timeframe_types: list[str] = [
             self.TIMEFRAME_TYPE_MIN,
             self.TIMEFRAME_TYPE_DAY,
+            self.TIMEFRAME_TYPE_TICK,
         ]
 
     def login(

--- a/integrate/data.py
+++ b/integrate/data.py
@@ -153,6 +153,13 @@ class IntegrateData:
                                 "volume": int(data[5]),
                                 "oi": int(data[6]),
                             }
+                        elif len(data) == 4:
+                            yield {
+                                "utc": data[0],
+                                "ltp": float(data[1]),
+                                "ltq": float(data[2]),
+                                "oi": float(data[3]),                             
+                            }
                         else:
                             yield {
                                 "datetime": datetime.strptime(


### PR DESCRIPTION
I have made some changes in the data.py and connect.py files to display tick data correctly. Currently, the API doesn't have this feature.

## Tick time frame

```bash
Add to connect.py file

TIMEFRAME_TYPE_MIN = "minute"
TIMEFRAME_TYPE_DAY = "day"
TIMEFRAME_TYPE_TICK = "tick"

self.timeframe_types: list[str] = [
self.TIMEFRAME_TYPE_MIN,
self.TIMEFRAME_TYPE_DAY,
self.TIMEFRAME_TYPE_TICK,
]
```

## Tick data

```bash
add to data.py file

def historical_data(): method name

elif len(data) == 4:
    yield {
        "utc": data[0],
        "ltp": float(data[1]),
        "ltq": float(data[2]),
        "oi": float(data[3]),                             
    }
```