### PR TITLE
Update connect.py

### DIFF
--- a/integrate/connect.py
+++ b/integrate/connect.py
@@ -341,7 +341,7 @@ class ConnectToIntegrate:
                     "option_type": line[8],
                     "strike": str(
                         int(
-                            int(line[9]) / (int(line[11]) * 10 ^ int(line[10]))
+                            int(line[9]) / (int(line[11]) * 10 ** int(line[10]))
                         )
                     ),
                     "isin": line[12],


### PR DESCRIPTION
Bug fix for Strike Calculation in symbols function. It was using XOR, instead of Exponentiation.